### PR TITLE
Add calls to Google Calendar API to get calendar events

### DIFF
--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -129,6 +129,7 @@ function do_google_api() {
             }
         };
         req.send();
+    }
 }
 
 // When you click on Settings in Pebble's phone app. Go to the configuration.html page.

--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -103,7 +103,32 @@ function refresh_access_token(refresh_token, code) {
 function do_google_api() {
     use_access_token(function(access_token) {
         // Use access token to make request to Calendar API
-    });
+        var req = new XMLHttpRequest();
+        req.open("GET", "https://www.googleapis.com/calendar/v3/users/me/calendarList?access_token=" + access_token, true);
+        req.onload = function(e) {
+            if (req.readyState == 4 && req.status == 200) {
+                // Get list of Calendars https://developers.google.com/google-apps/calendar/v3/reference/calendarList/list
+                var result = JSON.parse(req.responseText);
+                // Get Calendars https://developers.google.com/google-apps/calendar/v3/reference/calendarList#resource
+                var calenders = result.items;
+                if (!calendars || calendars.length === 0) {
+                    return;
+                }
+                req = new XMLHttpRequest():
+                req.open("GET", "https://www.googleapis.com/calendar/v3/calendars/" + calendars[0].id + "/events?maxResults=10&orderBy=startTime", true)
+                req.onload = function(e) {
+                    if (req.readyState = 4 && req.status == 200) {
+                        // Get list of events https://developers.google.com/google-apps/calendar/v3/reference/events/list
+                        result = JSON.parse(req.responseText);
+                        // Get events https://developers.google.com/google-apps/calendar/v3/reference/events#resource
+                        var events = result.items;
+                        // Do stuff with events here
+                    }
+                }
+                req.send();
+            }
+        };
+        req.send();
 }
 
 // When you click on Settings in Pebble's phone app. Go to the configuration.html page.


### PR DESCRIPTION
This should call the Google Calendar API after validating the access token. It should return a list of events for the user's first calendar.

In the future we should add functionality so the user can choose which calendar they would like to pull their events from.
